### PR TITLE
feat: throw error in 3 mins

### DIFF
--- a/lesson08/main.js
+++ b/lesson08/main.js
@@ -48,6 +48,6 @@ getMenus.then(
   	renderMenus(menus);
 	},
 	(error) => {
-		console.error("error", error);
+		console.error(error);
 	}
 );

--- a/lesson08/main.js
+++ b/lesson08/main.js
@@ -31,18 +31,23 @@ function renderMenus(menus){
   ul.appendChild(fragment);
 }
 
-const getMenus = new Promise((resolve)=> {
+const getMenus = new Promise((resolve, reject)=> {
   renderCircle();
   const menus = [ 
     {to: "bookmark.html", img:"img/1.png", alt:"画像1", text: "ブックマーク"}, 
     {to: "message.html", img:"img/2.png", alt:"画像2", text: "メッセージ"} 
   ]; 
   setTimeout(() => {
-    resolve(menus);
+    reject(new Error("error"));
   }, 3000);
 })
 
-getMenus.then((menus)=> {
-  removeCircle();
-  renderMenus(menus);
-});
+getMenus.then(
+	(menus)=> {
+  	removeCircle();
+  	renderMenus(menus);
+	},
+	(error) => {
+		console.log("error", error.message);
+	}
+);

--- a/lesson08/main.js
+++ b/lesson08/main.js
@@ -48,6 +48,6 @@ getMenus.then(
   	renderMenus(menus);
 	},
 	(error) => {
-		console.log("error", error.message);
+		console.error("error", error.message);
 	}
 );

--- a/lesson08/main.js
+++ b/lesson08/main.js
@@ -38,7 +38,7 @@ const getMenus = new Promise((resolve, reject)=> {
     {to: "message.html", img:"img/2.png", alt:"画像2", text: "メッセージ"} 
   ]; 
   setTimeout(() => {
-    reject(new Error("error"));
+    reject("error");
   }, 3000);
 })
 
@@ -48,6 +48,6 @@ getMenus.then(
   	renderMenus(menus);
 	},
 	(error) => {
-		console.error("error", error.message);
+		console.error("error", error);
 	}
 );


### PR DESCRIPTION
課題08
rejectを実行して、エラーを起こしてthenでエラーをキャッチ


https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#8

[codesandbox](https://codesandbox.io/s/github/groovywave/JS_Practice/tree/feat/lesson08/lesson08?file=/main.js) 

Latest commit:
904540adcbc5ffa89282a3acf9c8510a486c6652

課題08仕様
つぎはresolveで解決するのではなく(resolveを実行するのではなく) 3秒後にrejectを実行してthenでその値をコンソール出力してください。ローディングはぐるぐる状態で良いです。

いままでresolveとしていたところでrejectを実行して、エラーを起こしてthenでエラーをキャッチしてください

前回実装済
Loadingアイコンの表示。
3秒後にメニューアイコンの表示。

今回実装点
3秒後にrejectを実行してthenでその値をコンソール出力。

