### PR TITLE
feat: render menus in 3mins with async func

### DIFF
--- a/lesson09/.vscode/settings.json
+++ b/lesson09/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-	"liveServer.settings.port": 5501
+	"liveServer.settings.port": 5502
 }

--- a/lesson09/.vscode/settings.json
+++ b/lesson09/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"liveServer.settings.port": 5501
+}

--- a/lesson09/main.js
+++ b/lesson09/main.js
@@ -32,6 +32,7 @@ function renderMenus(menus){
 }
 
 const getMenus = new Promise((resolve)=> {
+	renderCircle();
 	const menus = [ 
 		{to: "bookmark.html", img:"img/1.png", alt:"画像1", text: "ブックマーク"}, 
     {to: "message.html", img:"img/2.png", alt:"画像2", text: "メッセージ"} 
@@ -47,5 +48,4 @@ async function showMenus() {
 	renderMenus(menus);
 }
 
-renderCircle();
 showMenus();

--- a/lesson09/main.js
+++ b/lesson09/main.js
@@ -30,19 +30,21 @@ function renderMenus(menus){
   ul.appendChild(fragment);
 }
 
-const getMenus = new Promise((resolve)=> {
-	renderCircle();
-	const menus = [ 
-		{to: "bookmark.html", img:"img/1.png", alt:"画像1", text: "ブックマーク"}, 
-    {to: "message.html", img:"img/2.png", alt:"画像2", text: "メッセージ"} 
-  ]; 
-  setTimeout(() => {
-		resolve(menus);
-  }, 3000);
-})
-
+function getMenus(){
+	return new Promise((resolve)=> {
+		renderCircle();
+		const menus = [ 
+			{to: "bookmark.html", img:"img/1.png", alt:"画像1", text: "ブックマーク"}, 
+			{to: "message.html", img:"img/2.png", alt:"画像2", text: "メッセージ"} 
+		]; 
+		setTimeout(() => {
+			resolve(menus);
+		}, 3000);
+	})
+}
+	
 async function showMenus() {
-	const menus = await getMenus;
+	const menus = await getMenus();
 	removeCircle();
 	renderMenus(menus);
 }

--- a/lesson09/main.js
+++ b/lesson09/main.js
@@ -31,25 +31,21 @@ function renderMenus(menus){
   ul.appendChild(fragment);
 }
 
-function getMenus() {
+const getMenus = new Promise((resolve)=> {
   renderCircle();
   const menus = [ 
     {to: "bookmark.html", img:"img/1.png", alt:"画像1", text: "ブックマーク"}, 
     {to: "message.html", img:"img/2.png", alt:"画像2", text: "メッセージ"} 
   ]; 
   setTimeout(() => {
-		console.log(menus);
-    return menus;
+    resolve(menus);
   }, 3000);
+})
+
+async function deployMenus() {
+	const menus = await getMenus;
+	await removeCircle();
+	await renderMenus(menus);
 }
 
-async function men() {
-	 await getMenus();
-	 removeCircle();
-}
-	// await renderMenus(menus);
-let val = men();
-console.log(val);
-val.then((val) =>{
-	renderMenus(val);
-})
+deployMenus();

--- a/lesson09/main.js
+++ b/lesson09/main.js
@@ -32,20 +32,20 @@ function renderMenus(menus){
 }
 
 const getMenus = new Promise((resolve)=> {
-  renderCircle();
-  const menus = [ 
-    {to: "bookmark.html", img:"img/1.png", alt:"画像1", text: "ブックマーク"}, 
+	const menus = [ 
+		{to: "bookmark.html", img:"img/1.png", alt:"画像1", text: "ブックマーク"}, 
     {to: "message.html", img:"img/2.png", alt:"画像2", text: "メッセージ"} 
   ]; 
   setTimeout(() => {
-    resolve(menus);
+		resolve(menus);
   }, 3000);
 })
 
-async function deployMenus() {
+async function showMenus() {
 	const menus = await getMenus;
-	await removeCircle();
-	await renderMenus(menus);
+	removeCircle();
+	renderMenus(menus);
 }
 
-deployMenus();
+renderCircle();
+showMenus();

--- a/lesson09/main.js
+++ b/lesson09/main.js
@@ -1,7 +1,7 @@
+const ul = document.getElementById("js-ul"); 
 
 function renderCircle(){
-  const loadingCircle = document.createElement("img"); 
-  const ul = document.getElementById("js-ul"); 
+	const loadingCircle = document.createElement("img"); 
   loadingCircle.src = "img/loading-circle.gif";
   loadingCircle.alt = "ローディング画像";
   loadingCircle.id = "loading-circle";
@@ -13,7 +13,6 @@ function removeCircle(){
 }
 
 function renderMenus(menus){
-  const ul = document.getElementById("js-ul"); 
   const fragment = document.createDocumentFragment(); 
   for (const menu of menus) { 
     const li = document.createElement("li"); 


### PR DESCRIPTION
[Task09]
async awaitを使って同じことをやってください。
rejectは考慮しないでいいです。
問題7をasync awaitを使って書いてください
https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#9


[codesandbox](https://codesandbox.io/s/github/groovywave/JS_Practice/tree/feat/lesson09/lesson09?file=/main.js)

[latest commit](c3a2e35d7fe737928124a931d31e352d0e4cf4ae)

前回実装済
resolveになるまでの間loading画像をだして、終わったら除いて メニューアイコン等を表示


今回実装点
async関数で書き換え

