### PR TITLE
Lesson18 Make pagenation with dots under the carousel

### DIFF
--- a/lesson18/css/slide.css
+++ b/lesson18/css/slide.css
@@ -37,7 +37,11 @@
 .next:hover {
   opacity: 0.8;
 }
-
+.prev.disabled-button:hover,
+.next.disabled-button:hover {
+  opacity: 1;
+  cursor: default ;
+}
 .prev {
   left: 0;
 }

--- a/lesson18/css/slide.css
+++ b/lesson18/css/slide.css
@@ -46,6 +46,28 @@
   right: 0;
 }
 
-#js-current {
+#js-currentSlide {
   z-index: 1;
+}
+
+#dotsContainer {
+  margin-top: 16px;
+  text-align: center;
+}
+
+#dotsContainer button + button {
+  margin-left: 8px;
+}
+
+#dotsContainer button {
+  border: none;
+  width: 16px;
+  height: 16px;
+  background: #ddd;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+#dotsContainer #js-currentDot {
+  background: #bbb;
 }

--- a/lesson18/css/slide.css
+++ b/lesson18/css/slide.css
@@ -46,7 +46,7 @@
   right: 0;
 }
 
-#js-currentSlide {
+.current-slide {
   z-index: 1;
 }
 
@@ -68,6 +68,6 @@
   cursor: pointer;
 }
 
-#dotsContainer #js-currentDot {
+#dotsContainer .current-dot {
   background: #bbb;
 }

--- a/lesson18/css/slide.css
+++ b/lesson18/css/slide.css
@@ -37,11 +37,13 @@
 .next:hover {
   opacity: 0.8;
 }
-.prev.disabled-button:hover,
-.next.disabled-button:hover {
+
+.prev:disabled,
+.next:disabled { 
   opacity: 1;
   cursor: default ;
 }
+
 .prev {
   left: 0;
 }

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -203,7 +203,7 @@ async function fetchMakeSlide() {
 }
 
 let intervalId;
-function advanceSlidesEvery3Sec() {
+function startAutoPlaySlides() {
   intervalId = setInterval(() => {
     currentIndex = ++currentIndex % slides.length;
     updateSlides();
@@ -215,12 +215,12 @@ function advanceSlidesEvery3Sec() {
 
 function resetSlideshowInterval() {
   clearInterval(intervalId);
-  advanceSlidesEvery3Sec();
+  startAutoPlaySlides();
 }
 
 async function init() {
   await fetchMakeSlide();
-  advanceSlidesEvery3Sec();
+  startAutoPlaySlides();
 }
 
 init();

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -41,16 +41,11 @@ function updateSlides() {
 function updateButtons() {
   document.getElementById("js-prev").disabled = false;
   document.getElementById("js-next").disabled = false;
-  document
-    .getElementsByClassName("disabled-button")[0]
-    ?.classList.remove("disabled-button");
   if (currentIndex === 0) {
     document.getElementById("js-prev").disabled = true;
-    document.getElementById("js-prev").classList.add("disabled-button");
   }
   if (currentIndex === slides.length - 1) {
     document.getElementById("js-next").disabled = true;
-    document.getElementById("js-next").classList.add("disabled-button");
   }
 }
 

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -33,7 +33,7 @@ function updateSlides() {
   slides[currentIndex].id = "js-current";
 }
 
-function updateButton() {
+function updateButtons() {
   document.getElementById("js-prev").disabled = false;
   document.getElementById("js-next").disabled = false;
   if (currentIndex === 0) {
@@ -53,14 +53,14 @@ function updateSlidesNumber() {
 function slidesMovePrev() {
   --currentIndex;
   updateSlides();
-  updateButton();
+  updateButtons();
   updateSlidesNumber();
 }
 
 function slidesMoveNext() {
   ++currentIndex;
   updateSlides();
-  updateButton();
+  updateButtons();
   updateSlidesNumber();
 }
 
@@ -97,6 +97,29 @@ function makeSlidesNumber() {
   carousel.appendChild(slidesNumber);
 }
 
+function makeDots() {
+  for (let i = 0; i < slides.length; i++) {
+    const button = document.createElement("button");
+    button.addEventListener("click", () => {
+      currentIndex = i;
+      updateDots();
+      updateButtons();
+      updateSlides();
+    });
+    dots.push(button);
+    document.getElementsByClassName("nav")[0].appendChild(button);
+  }
+
+  dots[0].classList.add("js-current");
+}
+
+function updateDots() {
+  dots.forEach((dot) => {
+    dot.classList.remove("current");
+  });
+  dots[currentIndex].classList.add("current");
+}
+
 function makeSlide(images) {
   const slidesContainer = document.createElement("div");
   slidesContainer.className = "slides-container";
@@ -116,7 +139,8 @@ function makeSlide(images) {
     .appendChild(slidesContainer)
     .appendChild(fragment);
   makeSlidesNumber();
-  updateButton();
+  updateButtons();
+  makeDots();
 }
 
 async function fetchData(url) {

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -41,11 +41,16 @@ function updateSlides() {
 function updateButtons() {
   document.getElementById("js-prev").disabled = false;
   document.getElementById("js-next").disabled = false;
+  document
+    .getElementsByClassName("disabled-button")[0]
+    ?.classList.remove("disabled-button");
   if (currentIndex === 0) {
     document.getElementById("js-prev").disabled = true;
+    document.getElementById("js-prev").classList.add("disabled-button");
   }
   if (currentIndex === slides.length - 1) {
     document.getElementById("js-next").disabled = true;
+    document.getElementById("js-next").classList.add("disabled-button");
   }
 }
 

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -180,4 +180,15 @@ async function fetchMakeSlide() {
   }
 }
 
-fetchMakeSlide();
+async function init() {
+  await fetchMakeSlide();
+  setInterval(() => {
+    currentIndex = ++currentIndex % slides.length;
+    updateSlides();
+    updateButtons();
+    updateSlidesNumber();
+    updateDots();
+  }, 3000);
+}
+
+init();

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -84,6 +84,7 @@ carousel.className = "carousel";
 
 function makePrevButton() {
   const prevButton = document.createElement("button");
+  prevButton.type = "button";
   prevButton.id = "js-prev";
   prevButton.className = "prev";
   prevButton.style.zIndex = 100;
@@ -95,6 +96,7 @@ function makePrevButton() {
 
 function makeNextButton() {
   const nextButton = document.createElement("button");
+  nextButton.type = "button";
   nextButton.id = "js-next";
   nextButton.className = "next";
   nextButton.style.zIndex = 100;

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -32,6 +32,10 @@ function displayInfo(error) {
 function updateSlides() {
   document.getElementById("js-currentSlide").id = "";
   slides[currentIndex].id = "js-currentSlide";
+  document
+    .getElementsByClassName("current-slide")[0]
+    .classList.remove("current-slide");
+  slides[currentIndex].classList.add("current-slide");
 }
 
 function updateButtons() {
@@ -122,12 +126,17 @@ function makeDots() {
   });
 
   dots[0].id = "js-currentDot";
+  dots[0].classList.add("current-dot");
   carousel.appendChild(dotsContainer);
 }
 
 function updateDots() {
   document.getElementById("js-currentDot").id = "";
   dots[currentIndex].id = "js-currentDot";
+  document
+    .getElementsByClassName("current-dot")[0]
+    .classList.remove("current-dot");
+  dots[currentIndex].classList.add("current-dot");
 }
 
 function makeSlide(images) {
@@ -142,6 +151,7 @@ function makeSlide(images) {
     slides.push(slide);
   });
   slides[currentIndex].id = "js-currentSlide";
+  slides[currentIndex].classList.add("current-slide");
   makePrevButton();
   makeNextButton();
   document.body

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -104,17 +104,20 @@ function makeDots() {
   const dotsContainer = document.createElement("div");
   dotsContainer.id = "dotsContainer";
   for (let i = 0; i < slides.length; i++) {
-    const button = document.createElement("button");
-    button.addEventListener("click", () => {
-      currentIndex = i;
-      updateDots();
-      updateButtons();
-      updateSlides();
-      updateSlidesNumber();
-    });
-    dots.push(button);
-    dotsContainer.appendChild(button);
+    const dot = document.createElement("button");
+    dot.dataset.index = i;
+    dots.push(dot);
+    dotsContainer.appendChild(dot);
   }
+  dotsContainer.addEventListener("click", (e) => {
+    if (e.target === e.currentTarget) return;
+    console.log(e.target);
+    currentIndex = parseInt(e.target.dataset.index, 10);
+    updateDots();
+    updateButtons();
+    updateSlides();
+    updateSlidesNumber();
+  });
 
   dots[0].id = "js-currentDot";
   carousel.appendChild(dotsContainer);

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -1,6 +1,7 @@
 let slides = [];
 const url = "https://mocki.io/v1/010175de-0176-440a-9f90-d4a7ca8010cc";
 let currentIndex = 0;
+let dots = [];
 
 function renderCircle() {
   const loadingCircleContainer = document.createElement("div");
@@ -29,8 +30,8 @@ function displayInfo(error) {
 }
 
 function updateSlides() {
-  document.getElementById("js-current").id = "";
-  slides[currentIndex].id = "js-current";
+  document.getElementById("js-currentSlide").id = "";
+  slides[currentIndex].id = "js-currentSlide";
 }
 
 function updateButtons() {
@@ -55,6 +56,7 @@ function slidesMovePrev() {
   updateSlides();
   updateButtons();
   updateSlidesNumber();
+  updateDots();
 }
 
 function slidesMoveNext() {
@@ -62,6 +64,7 @@ function slidesMoveNext() {
   updateSlides();
   updateButtons();
   updateSlidesNumber();
+  updateDots();
 }
 
 const fragment = document.createDocumentFragment();
@@ -98,6 +101,8 @@ function makeSlidesNumber() {
 }
 
 function makeDots() {
+  const dotsContainer = document.createElement("div");
+  dotsContainer.id = "dotsContainer";
   for (let i = 0; i < slides.length; i++) {
     const button = document.createElement("button");
     button.addEventListener("click", () => {
@@ -105,19 +110,19 @@ function makeDots() {
       updateDots();
       updateButtons();
       updateSlides();
+      updateSlidesNumber();
     });
     dots.push(button);
-    document.getElementsByClassName("nav")[0].appendChild(button);
+    dotsContainer.appendChild(button);
   }
 
-  dots[0].classList.add("js-current");
+  dots[0].id = "js-currentDot";
+  carousel.appendChild(dotsContainer);
 }
 
 function updateDots() {
-  dots.forEach((dot) => {
-    dot.classList.remove("current");
-  });
-  dots[currentIndex].classList.add("current");
+  document.getElementById("js-currentDot").id = "";
+  dots[currentIndex].id = "js-currentDot";
 }
 
 function makeSlide(images) {
@@ -131,7 +136,7 @@ function makeSlide(images) {
     fragment.appendChild(slide);
     slides.push(slide);
   });
-  slides[currentIndex].id = "js-current";
+  slides[currentIndex].id = "js-currentSlide";
   makePrevButton();
   makeNextButton();
   document.body

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -45,7 +45,7 @@ function updateButtons() {
   }
 }
 
-function updateSlidesNumber() {
+function updateSlideNumber() {
   document.getElementById("js-slidesNumber").textContent = `${
     currentIndex + 1
   }/${slides.length}`;
@@ -55,16 +55,18 @@ function slidesMovePrev() {
   --currentIndex;
   updateSlides();
   updateButtons();
-  updateSlidesNumber();
+  updateSlideNumber();
   updateDots();
+  resetSlideshowInterval();
 }
 
 function slidesMoveNext() {
   ++currentIndex;
   updateSlides();
   updateButtons();
-  updateSlidesNumber();
+  updateSlideNumber();
   updateDots();
+  resetSlideshowInterval();
 }
 
 const fragment = document.createDocumentFragment();
@@ -116,7 +118,8 @@ function makeDots() {
     updateDots();
     updateButtons();
     updateSlides();
-    updateSlidesNumber();
+    updateSlideNumber();
+    resetSlideshowInterval();
   });
 
   dots[0].id = "js-currentDot";
@@ -183,15 +186,25 @@ async function fetchMakeSlide() {
   }
 }
 
-async function init() {
-  await fetchMakeSlide();
-  setInterval(() => {
+let intervalId;
+function advanceSlidesEvery3Sec() {
+  intervalId = setInterval(() => {
     currentIndex = ++currentIndex % slides.length;
     updateSlides();
     updateButtons();
-    updateSlidesNumber();
+    updateSlideNumber();
     updateDots();
   }, 3000);
+}
+
+function resetSlideshowInterval() {
+  clearInterval(intervalId);
+  advanceSlidesEvery3Sec();
+}
+
+async function init() {
+  await fetchMakeSlide();
+  advanceSlidesEvery3Sec();
 }
 
 init();

--- a/lesson18/main.js
+++ b/lesson18/main.js
@@ -113,7 +113,6 @@ function makeDots() {
   }
   dotsContainer.addEventListener("click", (e) => {
     if (e.target === e.currentTarget) return;
-    console.log(e.target);
     currentIndex = parseInt(e.target.dataset.index, 10);
     updateDots();
     updateButtons();


### PR DESCRIPTION
# [Issue No.18](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/18.md#)
- スライドショーにドットのページネーションを作りましょう。
## [CodeSandBox](https://codesandbox.io/s/github/groovywave/JS_Practice/tree/lesson18/lesson18)<br>

 仕様
- それぞれのドットではクリッカブルになっていて、押下するとその画像に切り替わる。
- それとともに1/5も切り替わる。 
- また、3秒毎に次のスライドに自動で切り替わるauto機能を提供する。


前回実装済
- 画面遷移してから3秒後に解決されるPromiseが返すオブジェクトを元にimgタグを5つつくる。
[以前使ったmy jsonを使う](https://myjson.dit.upm.es/)
- それぞれは.z-indexで重ねた状態。矢印画像をクリックを押すとスライド画像が変わる。
- 5枚中何枚目かを表示して、5/5の場合Nextの矢印はdisabledにする。1/5枚の時はBackボタンはdisabledにする。


今回の対応内容
- それぞれのドットではクリッカブルになっていて、押下するとその画像に切り替わる。
- それとともに1/5も切り替わる。 
- また、3秒毎に次のスライドに自動で切り替わるauto機能を提供する。

<!--未実装部分
- 5枚中何枚目かを表示
-->
<!--
Concerns and areas to focus on<br>
- 実装上、不安なところ、重点的に見てもらいたいところ
-->