### PR TITLE
[Issue No.28] Add password validation on the reset page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "playwright": "^1.41.2"
       },
       "devDependencies": {
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.46.1",
         "@types/node": "^20.10.6",
         "autoprefixer": "^10.4.16",
         "eslint-plugin-tailwindcss": "^3.13.1",
@@ -491,18 +491,18 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
-      "integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
+      "integrity": "sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.41.2"
+        "playwright": "1.46.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@tailwindcss/container-queries": {
@@ -1279,31 +1279,31 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
-      "integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
+      "integrity": "sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==",
       "dependencies": {
-        "playwright-core": "1.41.2"
+        "playwright-core": "1.46.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-      "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
+      "integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.41.2",
+    "@playwright/test": "^1.46.1",
     "@types/node": "^20.10.6",
     "autoprefixer": "^10.4.16",
     "eslint-plugin-tailwindcss": "^3.13.1",

--- a/src/lesson28/js/forgot-password.js
+++ b/src/lesson28/js/forgot-password.js
@@ -46,6 +46,6 @@ buttonForResetPassword.addEventListener('click', async e => {
     window.location.href = `./register/password.html?resetPasswordToken=${resetPasswordToken}`;
   } catch (error) {
     // console.error(error?.message || 'An unknown error occurred.');
-    window.location.replace = './login-failed.html';
+    window.location.href = './login-failed.html';
   }
 });

--- a/src/lesson28/js/forgot-password.js
+++ b/src/lesson28/js/forgot-password.js
@@ -45,7 +45,7 @@ buttonForResetPassword.addEventListener('click', async e => {
     localStorage.setItem('resetPasswordToken', resetPasswordToken);
     window.location.href = `./register/password.html?resetPasswordToken=${resetPasswordToken}`;
   } catch (error) {
-    console.error(error?.message || 'An unknown error occurred.');
+    // console.error(error?.message || 'An unknown error occurred.');
     window.location.replace = './login-failed.html';
   }
 });

--- a/src/lesson28/js/resetPassword.js
+++ b/src/lesson28/js/resetPassword.js
@@ -34,7 +34,7 @@ submitButton.addEventListener('click', e => {
   const chance = new Chance();
   const token = chance.guid();
   localStorage.setItem('token', token);
-  window.location.replace(`./password-done.html?token=${token}`);
+  window.location.href(`./password-done.html?token=${token}`);
 });
 
 const stateOfPassword = getStateOfItem(password);

--- a/src/lesson28/js/resetPassword.js
+++ b/src/lesson28/js/resetPassword.js
@@ -74,37 +74,19 @@ function checkAndShowConfirmPasswordValidation() {
   validation.showSuccess(confirmPassword);
 }
 
-function checkAllItems() {
-  checkAndShowPasswordValidation();
-  checkAndShowConfirmPasswordValidation();
-}
-
-function checkAllItemsAndEnableSubmitButton() {
-  submitButton.disabled = true;
-  checkAllItems();
-  if (!validation.isEveryRequiredItemValid(stateOfItems)) return;
-  submitButton.disabled = false;
-}
-
 password.addEventListener('blur', () => {
   submitButton.disabled = true;
   checkAndShowPasswordValidation();
   if (!confirmPassword.value.trim()) return;
   checkAndShowConfirmPasswordValidation();
-  if (
-    stateOfConfirmPassword.isValid &&
-    !validation.isSomeRequiredItemEmpty(stateOfItems)
-  )
-    checkAllItemsAndEnableSubmitButton();
+  if (!validation.isEveryRequiredItemValid(stateOfItems)) return;
+  submitButton.disabled = false;
 });
 
 confirmPassword.addEventListener('blur', () => {
   submitButton.disabled = true;
   if (!password.value.trim()) return;
   checkAndShowConfirmPasswordValidation();
-  if (
-    stateOfConfirmPassword.isValid &&
-    !validation.isSomeRequiredItemEmpty(stateOfItems)
-  )
-    checkAllItemsAndEnableSubmitButton();
+  if (!validation.isEveryRequiredItemValid(stateOfItems)) return;
+  submitButton.disabled = false;
 });

--- a/src/lesson28/js/resetPassword.js
+++ b/src/lesson28/js/resetPassword.js
@@ -86,23 +86,21 @@ function checkAllItemsAndEnableSubmitButton() {
   submitButton.disabled = false;
 }
 
-let isConfirmPasswordAddedEventListener = false;
 password.addEventListener('input', () => {
   submitButton.disabled = true;
   checkAndShowPasswordValidation();
-  if (!isConfirmPasswordAddedEventListener) {
-    isConfirmPasswordAddedEventListener = true;
-    confirmPassword.addEventListener('input', () => {
-      submitButton.disabled = true;
-      checkAndShowConfirmPasswordValidation();
-      if (
-        stateOfConfirmPassword.isValid &&
-        !validation.isSomeRequiredItemEmpty(stateOfItems)
-      )
-        checkAllItemsAndEnableSubmitButton();
-    });
-  }
-  if (!confirmPassword.value) return;
+  if (!confirmPassword.value.trim()) return;
+  checkAndShowConfirmPasswordValidation();
+  if (
+    stateOfConfirmPassword.isValid &&
+    !validation.isSomeRequiredItemEmpty(stateOfItems)
+  )
+    checkAllItemsAndEnableSubmitButton();
+});
+
+confirmPassword.addEventListener('input', () => {
+  submitButton.disabled = true;
+  if (!password.value.trim()) return;
   checkAndShowConfirmPasswordValidation();
   if (
     stateOfConfirmPassword.isValid &&

--- a/src/lesson28/js/resetPassword.js
+++ b/src/lesson28/js/resetPassword.js
@@ -86,7 +86,7 @@ function checkAllItemsAndEnableSubmitButton() {
   submitButton.disabled = false;
 }
 
-password.addEventListener('input', () => {
+password.addEventListener('blur', () => {
   submitButton.disabled = true;
   checkAndShowPasswordValidation();
   if (!confirmPassword.value.trim()) return;
@@ -98,7 +98,7 @@ password.addEventListener('input', () => {
     checkAllItemsAndEnableSubmitButton();
 });
 
-confirmPassword.addEventListener('input', () => {
+confirmPassword.addEventListener('blur', () => {
   submitButton.disabled = true;
   if (!password.value.trim()) return;
   checkAndShowConfirmPasswordValidation();

--- a/src/lesson28/js/resetPassword.js
+++ b/src/lesson28/js/resetPassword.js
@@ -37,10 +37,6 @@ submitButton.addEventListener('click', e => {
   window.location.replace(`./password-done.html?token=${token}`);
 });
 
-function toggleSubmitButton() {
-  submitButton.disabled = !submitButton.disabled;
-}
-
 const stateOfPassword = getStateOfItem(password);
 const stateOfConfirmPassword = getStateOfItem(confirmPassword);
 
@@ -83,11 +79,11 @@ function checkAllItems() {
   checkAndShowConfirmPasswordValidation();
 }
 
-function checkAllItemsAndToggleSubmitButton() {
+function checkAllItemsAndEnableSubmitButton() {
   submitButton.disabled = true;
   checkAllItems();
   if (!validation.isEveryRequiredItemValid(stateOfItems)) return;
-  toggleSubmitButton();
+  submitButton.disabled = false;
 }
 
 password.addEventListener('input', () => {
@@ -100,7 +96,7 @@ password.addEventListener('input', () => {
       stateOfConfirmPassword.isValid &&
       !validation.isSomeRequiredItemEmpty(stateOfItems)
     )
-      checkAllItemsAndToggleSubmitButton();
+      checkAllItemsAndEnableSubmitButton();
   });
   if (!confirmPassword.value) return;
   checkAndShowConfirmPasswordValidation();
@@ -108,5 +104,5 @@ password.addEventListener('input', () => {
     stateOfConfirmPassword.isValid &&
     !validation.isSomeRequiredItemEmpty(stateOfItems)
   )
-    checkAllItemsAndToggleSubmitButton();
+    checkAllItemsAndEnableSubmitButton();
 });

--- a/src/lesson28/js/resetPassword.js
+++ b/src/lesson28/js/resetPassword.js
@@ -86,18 +86,22 @@ function checkAllItemsAndEnableSubmitButton() {
   submitButton.disabled = false;
 }
 
+let isConfirmPasswordAddedEventListener = false;
 password.addEventListener('input', () => {
   submitButton.disabled = true;
   checkAndShowPasswordValidation();
-  confirmPassword.addEventListener('input', () => {
-    submitButton.disabled = true;
-    checkAndShowConfirmPasswordValidation();
-    if (
-      stateOfConfirmPassword.isValid &&
-      !validation.isSomeRequiredItemEmpty(stateOfItems)
-    )
-      checkAllItemsAndEnableSubmitButton();
-  });
+  if (!isConfirmPasswordAddedEventListener) {
+    isConfirmPasswordAddedEventListener = true;
+    confirmPassword.addEventListener('input', () => {
+      submitButton.disabled = true;
+      checkAndShowConfirmPasswordValidation();
+      if (
+        stateOfConfirmPassword.isValid &&
+        !validation.isSomeRequiredItemEmpty(stateOfItems)
+      )
+        checkAllItemsAndEnableSubmitButton();
+    });
+  }
   if (!confirmPassword.value) return;
   checkAndShowConfirmPasswordValidation();
   if (

--- a/src/lesson28/js/resetPassword.js
+++ b/src/lesson28/js/resetPassword.js
@@ -74,19 +74,24 @@ function checkAndShowConfirmPasswordValidation() {
   validation.showSuccess(confirmPassword);
 }
 
+function enableSubmitWhenAllInputValid() {
+  if (!validation.isEveryRequiredItemValid(stateOfItems)) return;
+  submitButton.disabled = false;
+}
+
 password.addEventListener('blur', () => {
   submitButton.disabled = true;
+  if (!password.value.trim()) return;
   checkAndShowPasswordValidation();
   if (!confirmPassword.value.trim()) return;
   checkAndShowConfirmPasswordValidation();
-  if (!validation.isEveryRequiredItemValid(stateOfItems)) return;
-  submitButton.disabled = false;
+  enableSubmitWhenAllInputValid();
 });
 
 confirmPassword.addEventListener('blur', () => {
   submitButton.disabled = true;
   if (!password.value.trim()) return;
+  if (!confirmPassword.value.trim()) return;
   checkAndShowConfirmPasswordValidation();
-  if (!validation.isEveryRequiredItemValid(stateOfItems)) return;
-  submitButton.disabled = false;
+  enableSubmitWhenAllInputValid();
 });

--- a/src/lesson28/js/resetPassword.js
+++ b/src/lesson28/js/resetPassword.js
@@ -1,0 +1,112 @@
+import Chance from 'chance';
+import * as validation from './modules/validation.js';
+
+const password = document.getElementById('js-password');
+const confirmPassword = document.getElementById('js-confirmPassword');
+
+let baseStateOfItems = {
+  isEmpty: true,
+  isValid: false,
+  errorMessage: null,
+};
+
+let stateOfItems = [
+  {
+    item: password,
+    name: 'password',
+    ...baseStateOfItems,
+  },
+  {
+    item: confirmPassword,
+    name: 'confirmPassword',
+    ...baseStateOfItems,
+  },
+];
+
+function getStateOfItem(input) {
+  return stateOfItems.find(obj => obj.item === input);
+}
+
+const submitButton = document.getElementById('js-submitButton');
+
+submitButton.addEventListener('click', e => {
+  e.preventDefault();
+  const chance = new Chance();
+  const token = chance.guid();
+  localStorage.setItem('token', token);
+  window.location.replace(`./password-done.html?token=${token}`);
+});
+
+function toggleSubmitButton() {
+  submitButton.disabled = !submitButton.disabled;
+}
+
+const stateOfPassword = getStateOfItem(password);
+const stateOfConfirmPassword = getStateOfItem(confirmPassword);
+
+function checkAndShowPasswordValidation() {
+  if (validation.isEmpty(password.value, stateOfPassword)) {
+    validation.showError(password, stateOfPassword.errorMessage);
+    return;
+  }
+  if (!validation.isValidPassword(password.value, stateOfPassword)) {
+    stateOfPassword.isValid = false;
+    validation.showError(password, stateOfPassword.errorMessage);
+    return;
+  }
+  stateOfPassword.isValid = true;
+  validation.showSuccess(password);
+}
+
+function checkAndShowConfirmPasswordValidation() {
+  if (validation.isEmpty(confirmPassword.value, stateOfConfirmPassword)) {
+    validation.showError(confirmPassword, stateOfConfirmPassword.errorMessage);
+    return;
+  }
+  if (
+    !validation.isMatchingPasswords(
+      password.value,
+      confirmPassword.value,
+      stateOfConfirmPassword
+    )
+  ) {
+    stateOfConfirmPassword.isValid = false;
+    validation.showError(confirmPassword, stateOfConfirmPassword.errorMessage);
+    return;
+  }
+  stateOfConfirmPassword.isValid = true;
+  validation.showSuccess(confirmPassword);
+}
+
+function checkAllItems() {
+  checkAndShowPasswordValidation();
+  checkAndShowConfirmPasswordValidation();
+}
+
+function checkAllItemsAndToggleSubmitButton() {
+  submitButton.disabled = true;
+  checkAllItems();
+  if (!validation.isEveryRequiredItemValid(stateOfItems)) return;
+  toggleSubmitButton();
+}
+
+password.addEventListener('input', () => {
+  submitButton.disabled = true;
+  checkAndShowPasswordValidation();
+  confirmPassword.addEventListener('input', () => {
+    submitButton.disabled = true;
+    checkAndShowConfirmPasswordValidation();
+    if (
+      stateOfConfirmPassword.isValid &&
+      !validation.isSomeRequiredItemEmpty(stateOfItems)
+    )
+      checkAllItemsAndToggleSubmitButton();
+  });
+  if (!confirmPassword.value) return;
+  checkAndShowConfirmPasswordValidation();
+  if (
+    stateOfConfirmPassword.isValid &&
+    !validation.isSomeRequiredItemEmpty(stateOfItems)
+  )
+    checkAllItemsAndToggleSubmitButton();
+});

--- a/src/lesson28/register/password-done.html
+++ b/src/lesson28/register/password-done.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <link href="../input.css" rel="stylesheet" />
+    <link href="../../input.css" rel="stylesheet" />
     <title>Password Reset Successful</title>
   </head>
   <body>

--- a/src/lesson28/register/password.html
+++ b/src/lesson28/register/password.html
@@ -5,10 +5,61 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <link href="../../input.css" rel="stylesheet" />
-    <script src="../js/checkResetPasswordToken.js"></script>
+    <script type="module" src="../js/checkResetPasswordToken.js"></script>
+    <script type="module" src="../js/resetPassword.js"></script>
     <title>Reset Password</title>
   </head>
   <body>
     <h1>Reset Password</h1>
+    <form id="js-form" class="bg-gray-100 px-10 py-8">
+      <div class="relative mb-5">
+        <label
+          for="js-password"
+          class="mb-1 block pt-1 text-gray-700"
+          data-testid="test-passwordLabel"
+          >Password</label
+        >
+        <input
+          type="password"
+          id="js-password"
+          class="w-full rounded-lg border-2 border-gray-200 p-2 focus:outline-none"
+          placeholder="Enter password"
+          required
+        />
+        <small
+          class="invisible absolute mb-0 ml-0 block pb-2 leading-3 text-errorColor"
+          data-testid="test-passwordError"
+          >Error message</small
+        >
+      </div>
+      <div class="relative mb-6">
+        <label
+          for="js-confirmPassword"
+          class="mb-1 block pt-1 text-gray-700"
+          data-testid="test-confirmPasswordLabel"
+          >Confirm Password</label
+        >
+        <input
+          type="password"
+          id="js-confirmPassword"
+          class="w-full rounded-lg border-2 border-gray-200 p-2 focus:outline-none"
+          placeholder="Enter password again"
+          required
+        />
+        <small
+          class="invisible absolute mb-0 ml-0 block pb-2 leading-3 text-errorColor"
+          data-testid="test-confirmPasswordError"
+          >Error message</small
+        >
+      </div>
+      <button
+        id="js-submitButton"
+        type="submit"
+        class="w-full rounded-lg border-2 bg-green-300 px-4 py-2 font-bold text-white transition-colors duration-300 before:inset-0 before:border-0 before:border-white before:duration-100 before:ease-linear hover:bg-white hover:text-green-300 disabled:bg-gray-300 disabled:text-white"
+        disabled
+      >
+        Submit
+      </button>
+    </form>
   </body>
 </html>

--- a/src/lesson28/test/reset-password.spec.js
+++ b/src/lesson28/test/reset-password.spec.js
@@ -21,6 +21,7 @@ test('Input password and confirmPassword correctly and then to be visible the su
     .fill('111111Aa');
   await page.getByPlaceholder('Enter password again').click();
   await page.getByPlaceholder('Enter password again').fill('111111Aa');
+  await page.getByPlaceholder('Enter password again').blur();
   await expect(page.getByRole('button', { name: 'Submit' })).toBeEnabled();
 });
 
@@ -34,6 +35,7 @@ test.describe('Show validation Error', () => {
     await page
       .getByPlaceholder('Enter password', { exact: true })
       .fill('12345Aa');
+    await page.getByPlaceholder('Enter password', { exact: true }).blur();
     await expect(page.getByTestId('test-passwordError')).toBeVisible();
   });
   test('Input password without uppercase and show an error message', async ({
@@ -42,6 +44,7 @@ test.describe('Show validation Error', () => {
     await page
       .getByPlaceholder('Enter password', { exact: true })
       .fill('123456aa');
+    await page.getByPlaceholder('Enter password', { exact: true }).blur();
     await expect(page.getByTestId('test-passwordError')).toBeVisible();
   });
   test('Input password without lowercase and show an error message', async ({
@@ -50,6 +53,7 @@ test.describe('Show validation Error', () => {
     await page
       .getByPlaceholder('Enter password', { exact: true })
       .fill('123456AA');
+    await page.getByPlaceholder('Enter password', { exact: true }).blur();
     await expect(page.getByTestId('test-passwordError')).toBeVisible();
   });
   test('Input password without alphabets and show an error message', async ({
@@ -58,6 +62,7 @@ test.describe('Show validation Error', () => {
     await page
       .getByPlaceholder('Enter password', { exact: true })
       .fill('12345678');
+    await page.getByPlaceholder('Enter password', { exact: true }).blur();
     await expect(page.getByTestId('test-passwordError')).toBeVisible();
   });
   test('Input password without numbers and show an error message', async ({
@@ -66,6 +71,7 @@ test.describe('Show validation Error', () => {
     await page
       .getByPlaceholder('Enter password', { exact: true })
       .fill('abcdefgH');
+    await page.getByPlaceholder('Enter password', { exact: true }).blur();
     await expect(page.getByTestId('test-passwordError')).toBeVisible();
   });
   test('ConfirmPassword does not match with Password and show an error message', async ({
@@ -76,6 +82,7 @@ test.describe('Show validation Error', () => {
       .fill('111111Aa');
     await page.getByPlaceholder('Enter password again').click();
     await page.getByPlaceholder('Enter password again').fill('111111A');
+    await page.getByPlaceholder('Enter password again').blur();
     await expect(page.getByTestId('test-confirmPasswordError')).toBeVisible();
   });
 });

--- a/src/lesson28/test/reset-password.spec.js
+++ b/src/lesson28/test/reset-password.spec.js
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('http://localhost:3000/');
+  await page.getByRole('link', { name: 'lesson28' }).click();
+  await page.getByTestId('test-loginPageButton').click();
+  await page.getByRole('link', { name: 'Forgot password?' }).click();
+  await page.getByTestId('test-emailForResetPassword').click();
+  await page
+    .getByTestId('test-emailForResetPassword')
+    .fill('hasegawa@example.net');
+  await page.getByTestId('test-buttonForResetPassword').click();
+  await page.getByPlaceholder('Enter password', { exact: true }).click();
+});
+test('Input password and confirmPassword correctly and then to be visible the submit button', async ({
+  page,
+}) => {
+  await page
+    .getByPlaceholder('Enter password', { exact: true })
+    .fill('111111Aa');
+  await page.getByPlaceholder('Enter password again').click();
+  await page.getByPlaceholder('Enter password again').fill('111111Aa');
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+});
+test('Input password less than 8 letters and show an error message', async ({
+  page,
+}) => {
+  await page
+    .getByPlaceholder('Enter password', { exact: true })
+    .fill('12345Aa');
+  await expect(page.getByTestId('test-passwordError')).toBeVisible();
+});
+test('Input password without without uppercase and show an error message', async ({
+  page,
+}) => {
+  await page
+    .getByPlaceholder('Enter password', { exact: true })
+    .fill('123456aa');
+  await expect(page.getByTestId('test-passwordError')).toBeVisible();
+});
+test('Input password without lowercase and show an error message', async ({
+  page,
+}) => {
+  await page
+    .getByPlaceholder('Enter password', { exact: true })
+    .fill('123456AA');
+  await expect(page.getByTestId('test-passwordError')).toBeVisible();
+});
+test('Input password without alphabets and show an error message', async ({
+  page,
+}) => {
+  await page
+    .getByPlaceholder('Enter password', { exact: true })
+    .fill('12345678');
+  await expect(page.getByTestId('test-passwordError')).toBeVisible();
+});
+test('Input password without numbers and show an error message', async ({
+  page,
+}) => {
+  await page
+    .getByPlaceholder('Enter password', { exact: true })
+    .fill('abcdefgH');
+  await expect(page.getByTestId('test-passwordError')).toBeVisible();
+});

--- a/src/lesson28/test/reset-password.spec.js
+++ b/src/lesson28/test/reset-password.spec.js
@@ -62,3 +62,13 @@ test('Input password without numbers and show an error message', async ({
     .fill('abcdefgH');
   await expect(page.getByTestId('test-passwordError')).toBeVisible();
 });
+test('ConfirmPassword does not match with Password and show an error message', async ({
+  page,
+}) => {
+  await page
+    .getByPlaceholder('Enter password', { exact: true })
+    .fill('111111Aa');
+  await page.getByPlaceholder('Enter password again').click();
+  await page.getByPlaceholder('Enter password again').fill('111111A');
+  await expect(page.getByTestId('test-confirmPasswordError')).toBeVisible();
+});

--- a/src/lesson28/test/reset-password.spec.js
+++ b/src/lesson28/test/reset-password.spec.js
@@ -12,6 +12,7 @@ test.beforeEach(async ({ page }) => {
   await page.getByTestId('test-buttonForResetPassword').click();
   await page.getByPlaceholder('Enter password', { exact: true }).click();
 });
+
 test('Input password and confirmPassword correctly and then to be visible the submit button', async ({
   page,
 }) => {
@@ -20,55 +21,61 @@ test('Input password and confirmPassword correctly and then to be visible the su
     .fill('111111Aa');
   await page.getByPlaceholder('Enter password again').click();
   await page.getByPlaceholder('Enter password again').fill('111111Aa');
-  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeEnabled();
 });
-test('Input password less than 8 letters and show an error message', async ({
-  page,
-}) => {
-  await page
-    .getByPlaceholder('Enter password', { exact: true })
-    .fill('12345Aa');
-  await expect(page.getByTestId('test-passwordError')).toBeVisible();
-});
-test('Input password without without uppercase and show an error message', async ({
-  page,
-}) => {
-  await page
-    .getByPlaceholder('Enter password', { exact: true })
-    .fill('123456aa');
-  await expect(page.getByTestId('test-passwordError')).toBeVisible();
-});
-test('Input password without lowercase and show an error message', async ({
-  page,
-}) => {
-  await page
-    .getByPlaceholder('Enter password', { exact: true })
-    .fill('123456AA');
-  await expect(page.getByTestId('test-passwordError')).toBeVisible();
-});
-test('Input password without alphabets and show an error message', async ({
-  page,
-}) => {
-  await page
-    .getByPlaceholder('Enter password', { exact: true })
-    .fill('12345678');
-  await expect(page.getByTestId('test-passwordError')).toBeVisible();
-});
-test('Input password without numbers and show an error message', async ({
-  page,
-}) => {
-  await page
-    .getByPlaceholder('Enter password', { exact: true })
-    .fill('abcdefgH');
-  await expect(page.getByTestId('test-passwordError')).toBeVisible();
-});
-test('ConfirmPassword does not match with Password and show an error message', async ({
-  page,
-}) => {
-  await page
-    .getByPlaceholder('Enter password', { exact: true })
-    .fill('111111Aa');
-  await page.getByPlaceholder('Enter password again').click();
-  await page.getByPlaceholder('Enter password again').fill('111111A');
-  await expect(page.getByTestId('test-confirmPasswordError')).toBeVisible();
+
+test.describe('Show validation Error', () => {
+  test.afterEach(async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+  test('Input password less than 8 letters and show an error message', async ({
+    page,
+  }) => {
+    await page
+      .getByPlaceholder('Enter password', { exact: true })
+      .fill('12345Aa');
+    await expect(page.getByTestId('test-passwordError')).toBeVisible();
+  });
+  test('Input password without uppercase and show an error message', async ({
+    page,
+  }) => {
+    await page
+      .getByPlaceholder('Enter password', { exact: true })
+      .fill('123456aa');
+    await expect(page.getByTestId('test-passwordError')).toBeVisible();
+  });
+  test('Input password without lowercase and show an error message', async ({
+    page,
+  }) => {
+    await page
+      .getByPlaceholder('Enter password', { exact: true })
+      .fill('123456AA');
+    await expect(page.getByTestId('test-passwordError')).toBeVisible();
+  });
+  test('Input password without alphabets and show an error message', async ({
+    page,
+  }) => {
+    await page
+      .getByPlaceholder('Enter password', { exact: true })
+      .fill('12345678');
+    await expect(page.getByTestId('test-passwordError')).toBeVisible();
+  });
+  test('Input password without numbers and show an error message', async ({
+    page,
+  }) => {
+    await page
+      .getByPlaceholder('Enter password', { exact: true })
+      .fill('abcdefgH');
+    await expect(page.getByTestId('test-passwordError')).toBeVisible();
+  });
+  test('ConfirmPassword does not match with Password and show an error message', async ({
+    page,
+  }) => {
+    await page
+      .getByPlaceholder('Enter password', { exact: true })
+      .fill('111111Aa');
+    await page.getByPlaceholder('Enter password again').click();
+    await page.getByPlaceholder('Enter password again').fill('111111A');
+    await expect(page.getByTestId('test-confirmPasswordError')).toBeVisible();
+  });
 });


### PR DESCRIPTION
# [Issue No.28]　Add password validation on the reset page.
(https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#28)

----------------------------------------------------------------

## [stackblitz](https://stackblitz.com/edit/stackblitz-starters-axeudy?file=README.md)
仕様
-「新規パスワード入力」 「確認のためのパスワード入力」 があり、バリデーションも効きます。
<!--
前回実装済
- 画面遷移してから3秒後に解決されるPromiseが返すオブジェクトを元にimgタグを5つつくる。
[以前使ったmy jsonを使う](https://myjson.dit.upm.es/)
- それぞれは.z-indexで重ねた状態。矢印画像をクリックを押すとスライド画像が変わる。
- 5枚中何枚目かを表示して、5/5の場合Nextの矢印はdisabledにする。1/5枚の時はBackボタンはdisabledにする。
-->

<!--前回実装済み
-こちらのようなテーブルを画面遷移してから3秒後に解決されるPromiseが返すオブジェクトを元に作り、 idがソートできる機能を作ってください
-ソートが昇順の場合は上矢印がアクティブ、下矢印がdisabled、1,2,3,4,5の順番で表示され、降順の場合はその逆、
-通常時の矢印クリック(クリッカブル領域は2つの矢印です。上下別々のクリッカブル領域でではなく)を押すと画像のように変化します
-->
<!--今回の対応内容
-同じことを年齢でもやってください。
-->

<!--Concerns and areas to focus on<br>
- 関数の配置の仕方（置き所）で悩んでいます。読みやすくするための改善点があればご教示いただきたいです。
実装上、不安なところ、重点的に見てもらいたいところ
- 抽象的にcodingできたとは思いますが、全体的に読みにくいコードにくなってしまいました。-->






https://github.com/user-attachments/assets/581c2a75-2b89-4f5c-8176-db2225b2c306








今回追加のテストコード
１．password confirmPasswordを正しく入力したときにsumitButtonが有効化されることを期待するテストです。

![image](https://github.com/user-attachments/assets/9e79f2a2-b1d2-4b7e-824b-6b0a046e3515)




２．password再設定の際、入力が８文字より少ない場合にerror messageが表示されることを期待するテストです。

![image](https://github.com/user-attachments/assets/627061ed-0f46-4f8d-98a4-47f83d581961)




３．password再設定の際、入力値に大文字がない場合にerror messageが表示されることを期待するテストです。

![image](https://github.com/user-attachments/assets/345b614a-b3d0-4f14-944f-cf974b425a21)


４．password再設定の際、入力値に小文字がない場合にerror messageが表示されることを期待するテストです。

![image](https://github.com/user-attachments/assets/f63c66e4-b0e1-4eb6-9efe-2b360339eb8a)


５．password再設定の際、入力値にアルファベットもしくは記号がない場合にerror messageが表示されることを期待するテストです。

![image](https://github.com/user-attachments/assets/8bc69fc8-e4f4-464c-94a3-ed2fa04fc552)

５．password再設定の際、入力値が数字だけであった場合にerror messageが表示されることを期待するテストです。

![image](https://github.com/user-attachments/assets/25b21793-2c4f-48d6-869e-c391251fbca3)

５．password再設定の際、入力値が数字だけであった場合にerror messageが表示されることを期待するテストです。

![image](https://github.com/user-attachments/assets/386204db-8711-40cf-9e80-186c823a39ba)



https://github.com/coderabbitai pause